### PR TITLE
fix: pyproject.toml project name issue & update README how to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A modern age calculator Android app built with Python and Flet Framework featuri
 ```bash
 git clone https://github.com/virendracarpenter/age-calculator-flet.git
 cd age-calculator-flet
-pip install -r requirements.txt
+pip install .
 flet run
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "Age Calculator"
+name = "age-calculator"
 version = "1.0.0"
 description = ""
 readme = "README.md"


### PR DESCRIPTION
Fixed project's name in the pyproject.toml file to allow "pip install ." to work.
Also updated README.md and replaced "pip install -r requirements.txt" because there is no requirements.txt file. The project uses pyproject.toml.